### PR TITLE
block all robots in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
 # To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Disallow: /


### PR DESCRIPTION
We can change this later, e.g. to configure it on a per-user basis, but defaulting to most-private seems best.