### PR TITLE
Add REGISTRATION_SECRET invite system

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -4,7 +4,19 @@ class AboutController < ApplicationController
   before_action :set_body_classes
   before_action :set_instance_presenter, only: [:show, :more]
 
-  def show; end
+  def show
+    registration_secret = ENV.fetch('REGISTRATION_SECRET', 'pineapples')
+    if registration_secret
+      # if url has the correct secret passphrase set, show the registration form
+      if params[:secret] == registration_secret
+        @show_registration = true
+      else
+        @show_registration = false
+      end
+    else
+      @show_registration = @instance_presenter.open_registrations
+    end
+  end
 
   def more; end
 

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -24,7 +24,7 @@
   .screenshot-with-signup
     .mascot= image_tag 'fluffy-elephant-friend.png'
 
-    - if @instance_presenter.open_registrations
+    - if @show_registration
       = render 'registration'
     - else
       .closed-registrations-message


### PR DESCRIPTION
Based on @amycheng's patch (https://github.com/amycheng/mastodon/pull/1), this PR allows us to set a special environment parameter (`REGISTRATION_SECRET`) so that when you go to `https://toot.cafe` it'll say "registrations are closed," whereas if you go to `https://toot.cafe?secret=password` then it will show registrations as open.

I tested locally and it seems to work. Assuming everything goes well, I will open up registrations tomorrow at 8am PDT and announce the passphrase on Twitter and Mastodon. (I'd like to do it tomorrow morning to make sure I can keep an eye on server load.)

/cc @rachelnicole @halkeye @luisbg @mlcdf