### PR TITLE
Slight tweak to REGISTRATION_SECRET system

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -6,7 +6,7 @@ class AboutController < ApplicationController
 
   def show
     registration_secret = ENV.fetch('REGISTRATION_SECRET', 'pineapples')
-    if registration_secret
+    if @instance_presenter.open_registrations && registration_secret
       # if url has the correct secret passphrase set, show the registration form
       if params[:secret] == registration_secret
         @show_registration = true


### PR DESCRIPTION
If registrations are closed, we should just always show "closed." It's only if they're open that the password system works.