### PR TITLE
Audio uploads

### DIFF
--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -207,6 +207,31 @@
     color: $ui-secondary-color;
   }
 
+  .metadata {
+    margin: 15px 0;
+    border: thin $ui-base-color solid;
+    border-collapse: collapse;
+    padding: 0;
+
+    th {
+      margin: 0;
+      border: thin $ui-base-color solid;
+      padding: 0 5px;
+      color: $ui-secondary-color;
+      background: darken($ui-base-color, 8%);
+      width: 94px;
+      vertical-align: middle;
+    }
+
+    td {
+      margin: 0;
+      border: thin $ui-base-color solid;
+      padding: 0 5px;
+      color: $ui-primary-color;
+      vertical-align: middle;
+    }
+  }
+
   @media screen and (max-width: 480px) {
     display: block;
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -40,12 +40,12 @@ class MediaAttachment < ApplicationRecord
       format: 'mp4',
       convert_options: {
         output: {
-          filter_complex: '"[0:a]compand,showwaves=s=640x360:mode=line,format=yuv420p[v]"',
+          filter_complex: '"[0:a]showwaves=s=320x180:mode=line,format=yuv420p[v]"',
           map: '"[v]" -map 0:a', 
-          threads: 2,
           vcodec: 'libx264',
           acodec: 'aac',
-          movflags: '+faststart',
+          crf: '35',
+          strict: '-2',
         },
       },
     },

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -53,6 +53,6 @@ class InitialStateSerializer < ActiveModel::Serializer
   end
 
   def media_attachments
-    { accept_content_types: MediaAttachment::IMAGE_FILE_EXTENSIONS + MediaAttachment::VIDEO_FILE_EXTENSIONS + MediaAttachment::IMAGE_MIME_TYPES + MediaAttachment::VIDEO_MIME_TYPES }
+    { accept_content_types: MediaAttachment::IMAGE_FILE_EXTENSIONS + MediaAttachment::VIDEO_FILE_EXTENSIONS + MediaAttachment::AUDIO_FILE_EXTENSIONS + MediaAttachment::IMAGE_MIME_TYPES + MediaAttachment::VIDEO_MIME_TYPES + MediaAttachment::AUDIO_MIME_TYPES }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 require_relative '../app/lib/exceptions'
 require_relative '../lib/paperclip/gif_transcoder'
 require_relative '../lib/paperclip/video_transcoder'
+require_relative '../lib/paperclip/audio_transcoder'
 require_relative '../lib/mastodon/snowflake'
 require_relative '../lib/mastodon/version'
 

--- a/lib/paperclip/audio_transcoder.rb
+++ b/lib/paperclip/audio_transcoder.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Paperclip
+  class AudioTranscoder < Paperclip::Processor
+    def make
+      meta = ::Av.cli.identify(@file.path)
+      # {:length=>"0:00:02.14", :duration=>2.14, :audio_encode=>"mp3", :audio_bitrate=>"44100 Hz", :audio_channels=>"mono"}
+      if meta[:duration] > 60.0
+        raise Mastodon::ValidationError, "Audio uploads must be less than 60 seconds in length."
+      end
+      
+      final_file = Paperclip::Transcoder.make(file, options, attachment)
+      
+      attachment.instance.file_file_name    = 'media.mp4'
+      attachment.instance.file_content_type = 'video/mp4'
+      attachment.instance.type              = MediaAttachment.types[:video]
+
+      final_file
+    end
+  end
+end

--- a/lib/paperclip/audio_transcoder.rb
+++ b/lib/paperclip/audio_transcoder.rb
@@ -5,8 +5,8 @@ module Paperclip
     def make
       meta = ::Av.cli.identify(@file.path)
       # {:length=>"0:00:02.14", :duration=>2.14, :audio_encode=>"mp3", :audio_bitrate=>"44100 Hz", :audio_channels=>"mono"}
-      if meta[:duration] > 60.0
-        raise Mastodon::ValidationError, "Audio uploads must be less than 60 seconds in length."
+      if meta[:duration] > 300.0
+        raise Mastodon::ValidationError, "Audio uploads must be less than 5 minutes in length."
       end
       
       final_file = Paperclip::Transcoder.make(file, options, attachment)


### PR DESCRIPTION
This includes https://github.com/glitch-soc/mastodon/pull/161 with some small tweaks:

- increase audio upload limit from 60 seconds to 5 minutes
- tweak the params so that the video output is lower-quality but it encodes faster

I tested this on a 4-minute mp3 on the toot.cafe server and it took 15 seconds and resulted in an mp3 file size of 7.1M. I tried some other files and they resulted in similar sizes.

Mastodon limits video uploads to 8M, so the effective limit is probably closer to 4m30s. I tested out a 5min file and it failed because it exceeded 8M after encoding.