### PR TITLE
Make elephant friend in compose drawer optional

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -43,6 +43,7 @@ class Settings::PreferencesController < ApplicationController
       :setting_system_font_ui,
       :setting_noindex,
       :setting_theme,
+      :setting_hide_elephant_fren,
       notification_emails: %i(follow follow_request reblog favourite mention digest),
       interactions: %i(must_be_follower must_be_following)
     )

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1778,6 +1778,16 @@
   }
 }
 
+.hide-elephant-fren {
+  .drawer__inner {
+    background: lighten($ui-base-color, 13%);
+    > .mastodon {
+      background: none;
+    }
+  }
+}
+
+
 .pseudo-drawer {
   background: lighten($ui-base-color, 13%);
   font-size: 13px;

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -27,6 +27,7 @@ class UserSettingsDecorator
     user.settings['system_font_ui']      = system_font_ui_preference if change?('setting_system_font_ui')
     user.settings['noindex']             = noindex_preference if change?('setting_noindex')
     user.settings['theme']               = theme_preference if change?('setting_theme')
+    user.settings['hide_elephant_fren']  = hide_elephant_fren_preference if change?('setting_hide_elephant_fren')
   end
 
   def merged_notification_emails
@@ -75,6 +76,10 @@ class UserSettingsDecorator
 
   def theme_preference
     settings['setting_theme']
+  end
+
+  def hide_elephant_fren_preference
+    boolean_cast_setting 'setting_hide_elephant_fren'
   end
 
   def boolean_cast_setting(key)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,7 @@ class User < ApplicationRecord
   has_many :session_activations, dependent: :destroy
 
   delegate :auto_play_gif, :default_sensitive, :unfollow_modal, :boost_modal, :delete_modal,
-           :reduce_motion, :system_font_ui, :noindex, :theme,
+           :reduce_motion, :system_font_ui, :noindex, :theme, :hide_elephant_fren,
            to: :settings, prefix: :setting, allow_nil: false
 
   attr_accessor :invite_code

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,6 +28,7 @@
   - body_classes ||= @body_classes || ''
   - body_classes += ' system-font' if current_account&.user&.setting_system_font_ui
   - body_classes += current_account&.user&.setting_reduce_motion ? ' reduce-motion' : ' no-reduce-motion'
+  - body_classes += current_account&.user&.setting_hide_elephant_fren ? ' hide-elephant-fren' : ''
 
   %body{ class: add_rtl_body_class(body_classes) }
     = content_for?(:content) ? yield(:content) : yield

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -37,6 +37,7 @@
     = f.input :setting_auto_play_gif, as: :boolean, wrapper: :with_label
     = f.input :setting_reduce_motion, as: :boolean, wrapper: :with_label
     = f.input :setting_system_font_ui, as: :boolean, wrapper: :with_label
+    = f.input :setting_hide_elephant_fren, as: :boolean, wrapper: :with_label
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -49,6 +49,7 @@ en:
         setting_reduce_motion: Reduce motion in animations
         setting_system_font_ui: Use system's default font
         setting_theme: Site theme
+        setting_hide_elephant_fren: Hide elephant friend in compose drawer
         setting_unfollow_modal: Show confirmation dialog before unfollowing someone
         severity: Severity
         type: Import type

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,7 @@ defaults: &defaults
   system_font_ui: false
   noindex: false
   theme: 'default'
+  hide_elephant_fren: false
   notification_emails:
     follow: false
     reblog: false


### PR DESCRIPTION
Add an option to hide the elephant friend in the compose drawer, which [some folks find distracting](https://toot.cafe/@jessiscah24/99302481465411795). This also matches the appearance in Mastodon <2.1.2.

![out](https://user-images.githubusercontent.com/283842/34643762-e52d2292-f2de-11e7-832d-42fe2bfaed38.png)
