### PR TITLE
Allow jyasskin's toots and profile to be indexed.

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow: /
+Allow: /@jyasskin/
+Allow: /@jyasskin$


### PR DESCRIPTION
You'd worried about this allowing other folks on this server to get indexed if they're part of a thread with me. That's already true if they're part of a thread with someone on another server. E.g. https://mastodon.social/@jyasskin/109254985745495620 shows your toots and can be indexed.

The main app appears to implement the setting with a `<meta name="robots" content="noindex, noarchive">` tag in the page's `<head>` rather than by manipulating the robots.txt file. See https://github.com/mastodon/mastodon/blob/26478f461cafc42d39bc0baf235989e1df7ee0bb/app/views/statuses/show.html.haml#L5-L6. That won't block reply threads either. I could imagine doing a bit better using Google's [`data-nosnippet` attribute](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#data-nosnippet-attr) ... but it would probably require this setting to get propagated through the ActivityPub protocol, which seems fairly involved.

Thanks for considering this!