### PR TITLE
fix: improve button a11y

### DIFF
--- a/app/javascript/styles/tootcafe.scss
+++ b/app/javascript/styles/tootcafe.scss
@@ -23,3 +23,8 @@ $base-shadow-color: $color8;
 $base-overlay-background: $color8;
 
 @import 'application';
+
+// Change the color of button texts to improve a11y
+.button, .simple_form button, .simple_form .button, .simple_form .block-button, .icon-with-badge__badge {
+  color: #141414;
+}


### PR DESCRIPTION
Improves the contrast ratio on the button from 2.62 to 7 (AAA).

Before:

![Screenshot from 2022-11-12 07-08-43](https://user-images.githubusercontent.com/283842/201480599-fe1e7f66-4324-4167-83e2-7d0c10f1b1e3.png)



After:

![Screenshot from 2022-11-12 07-07-04](https://user-images.githubusercontent.com/283842/201480602-11cede72-d627-4478-a686-99873e5c8b18.png)
